### PR TITLE
Add support for LED

### DIFF
--- a/flash/autoconfig/etc/init.d/S00autoled
+++ b/flash/autoconfig/etc/init.d/S00autoled
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+AUTOLED_ARGS=""
+AUTOLED_PID_FILE=/var/run/autoled.pid
+
+start() {
+  printf "Starting automatic LED control: "
+  umask 077
+  start-stop-daemon -b -m -S -q -p $AUTOLED_PID_FILE \
+    --exec /usr/sbin/autoled.sh -- $AUTOLED_ARGS
+  [ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+stop() {
+  printf "Stopping automatic LED control: "
+  start-stop-daemon -K -q -p $AUTOLED_PID_FILE
+  [ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+restart() {
+  stop
+  start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart | reload)
+    restart
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+    ;;
+esac
+
+exit $?

--- a/flash/autoconfig/usr/sbin/autoled.sh
+++ b/flash/autoconfig/usr/sbin/autoled.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Automatic LED control for Xiaomi MJSXJ03HL
+
+streamerProcess="majestic"
+serviceProcess="sysupgrade"
+pollingInterval=1
+
+show_help() {
+    echo "Usage: $0 [-p process] [-s process] [-i value] [-h]
+    -p process   Name of the monitored streamer process (default = ${streamerProcess}).
+    -s process   Name of the monitored service process (default = ${serviceProcess}).
+    -i value     Polling interval in seconds (default = ${pollingInterval}).
+    -h           Show this help."
+    exit 0
+}
+
+# override config values with command line arguments
+while getopts H:L:i:h flag; do
+    case ${flag} in
+        p) streamerProcess=${OPTARG} ;;
+        s) serviceProcess=${OPTARG} ;;
+        i) pollingInterval=${OPTARG} ;;
+        h | *) show_help ;;
+    esac
+done
+
+echo "...................."
+echo "Name of the monitored streamer process: ${streamerProcess}"
+echo "Name of the monitored service process: ${serviceProcess}"
+echo "Polling interval: ${pollingInterval} sec"
+echo "...................."
+
+led_state=0
+/usr/sbin/led_control.sh -o 0 -b 0
+echo "...................."
+
+while true; do
+    if killall -q -0 $serviceProcess; then
+        if [ $led_state -ne 3 ]; then
+            echo "Process $serviceProcess is running, turn on the white LED"
+            /usr/sbin/led_control.sh -o 1 -b 1
+            led_state=3
+            echo "...................."
+        fi
+    else
+        if [ $led_state -ne 1 ] && ! killall -q -0 $streamerProcess; then
+            echo "Process $streamerProcess is not running, turn on the orange LED"
+            /usr/sbin/led_control.sh -o 1 -b 0
+            led_state=1
+            echo "...................."
+        elif [ $led_state -ne 2 ] && killall -q -0 $streamerProcess; then
+            echo "Process $streamerProcess is running, turn on the blue LED"
+            /usr/sbin/led_control.sh -o 0 -b 1
+            led_state=2
+            echo "...................."
+        fi
+    fi
+    sleep $pollingInterval
+done

--- a/flash/autoconfig/usr/sbin/led_control.sh
+++ b/flash/autoconfig/usr/sbin/led_control.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# LED control for Xiaomi MJSXJ03HL
+
+show_help() {
+    echo "Usage: $0 [-o <0|1>] [-b <0|1>]
+    -o <0|1>   Switch state for orange LED.
+    -b <0|1>   Switch state for blue LED."
+    exit 0
+}
+
+led_control() {
+    echo "Switching LED with GPIO${1} to state ${2}"
+    if [ ! -d /sys/class/gpio/gpio${1}/ ]; then
+        echo ${1} > /sys/class/gpio/export
+        echo out > /sys/class/gpio/gpio${1}/direction
+    fi
+    echo ${2} > /sys/class/gpio/gpio${1}/value
+}
+
+if [ $# -eq 0 ]; then show_help; fi
+while getopts o:b: flag; do
+    case ${flag} in
+        o)
+            [ ${OPTARG} -eq 0 -o ${OPTARG} -eq 1 ] || show_help
+            led_control 39 ${OPTARG}
+            ;;
+        b)
+            [ ${OPTARG} -eq 0 -o ${OPTARG} -eq 1 ] || show_help
+            led_control 38 ${OPTARG}
+            ;;
+        *) show_help ;;
+    esac
+done


### PR DESCRIPTION
I've dumped the original firmware and found that LED's GPIOs are 38 for blue and 39 for orange. So I made an identical solution like in [device-mjsxj02hl](https://github.com/OpenIPC/device-mjsxj02hl)